### PR TITLE
Features: Priming, Z-dip, Z-movement commands

### DIFF
--- a/App_Common.cpp
+++ b/App_Common.cpp
@@ -1024,6 +1024,7 @@ void DisplayConfig(Gpu_Hal_Context_t *phost)
     Gpu_CoCmd_Text(phost, 179, 78, 20, OPT_CENTER | OPT_RIGHTX | OPT_FORMAT, "Column");
     Gpu_CoCmd_Text(phost, 121, 78, 20, OPT_CENTER | OPT_RIGHTX | OPT_FORMAT, "Row");
     Gpu_CoCmd_Text(phost, 255, 78, 20, OPT_CENTER | OPT_RIGHTX | OPT_FORMAT, "Cycles:");
+    Gpu_CoCmd_Text(phost, 255, 115, 20, OPT_CENTER | OPT_RIGHTX | OPT_FORMAT, "Z Dip:");
     Gpu_CoCmd_Text(phost, 51, 96, 21, OPT_CENTER | OPT_RIGHTX | OPT_FORMAT, "No. of Tube:");
     Gpu_CoCmd_Text(phost, 51, 123, 21, OPT_CENTER | OPT_RIGHTX | OPT_FORMAT, "Pitch(mm):");
     Gpu_CoCmd_Text(phost, 46, 179, 21, OPT_CENTER | OPT_RIGHTX | OPT_FORMAT, "Vibration:");
@@ -1091,6 +1092,13 @@ void DisplayConfig(Gpu_Hal_Context_t *phost)
 	App_WrCoCmd_Buffer(phost, VERTEX2F(3744, 1632));
 	App_WrCoCmd_Buffer(phost, VERTEX2F(4480, 1392));
 	App_WrCoCmd_Buffer(phost, TAG_MASK(0));
+
+	// Z Dip
+	App_WrCoCmd_Buffer(phost, TAG_MASK(1));
+	App_WrCoCmd_Buffer(phost, TAG(21));
+	App_WrCoCmd_Buffer(phost, VERTEX2F(3744, 2248));
+	App_WrCoCmd_Buffer(phost, VERTEX2F(4480, 2008));
+	App_WrCoCmd_Buffer(phost, TAG_MASK(0));  
 
 	App_WrCoCmd_Buffer(phost, END());
 
@@ -1203,6 +1211,13 @@ void DisplayConfig(Gpu_Hal_Context_t *phost)
   //Text - Cycles
 	sprintf(buf,"%d",CurProf.Cycles);
     Gpu_CoCmd_Text(phost, 255, 95, 21, OPT_CENTER | OPT_RIGHTX | OPT_FORMAT, buf);
+
+  //Text - Z Dip
+  
+	  sprintf(buf,"%f",CurProf.ZDip);
+    Dprint("ZDip =",CurProf.ZDip);
+    dtostrf(CurProf.ZDip,4,1,buf);
+    Gpu_CoCmd_Text(phost, 255, 133, 21, OPT_CENTER | OPT_RIGHTX | OPT_FORMAT, buf);
 
     App_WrCoCmd_Buffer(phost, COLOR_RGB(255, 255, 255));
     App_WrCoCmd_Buffer(phost, TAG_MASK(1));
@@ -1488,6 +1503,11 @@ void Config_Settings(Gpu_Hal_Context_t *phost)
               CurProf.Cycles=Keypad(&host, CurProf.Cycles, MINCYCLE,MAXCYCLE,FALSE);
               DisplayConfig(phost);
               break;
+		        case 21: //Z Dip
+              keypressed=0;
+              CurProf.ZDip=Keypad(&host, CurProf.ZDip, MINZDIP,MAXZDIP,FALSE);
+              DisplayConfig(phost);
+              break;              
 		        
 		        case 28: //Vibration Level
               keypressed=0;

--- a/Config.h
+++ b/Config.h
@@ -43,5 +43,8 @@
 // Defines if the dispenser should home the Z-axis during homing
 #define EXPERIMENTAL_Z_HOMING true 
 
+// Defines if the dispenser should perform a Z-Dip during a dispense action
+#define EXPERIMENTAL_Z_DIP true 
+
 // Defines if the dispenser should respond to Z-movement requests via PLC commands
 #define EXPERIMENTAL_Z_AXIS_MOVEMENT_API true 

--- a/Config.h
+++ b/Config.h
@@ -39,6 +39,9 @@
 #define motor_z_Acceleration 100000//4000 // 2400 1600 // 3200
 
 #define PRIME_DISPENSE_NUM 2
-#define EXPERIMENTAL_Z_AXIS_MOVEMENT_API true
+
 // Defines if the dispenser should home the Z-axis during homing
 #define EXPERIMENTAL_Z_HOMING true 
+
+// Defines if the dispenser should respond to Z-movement requests via PLC commands
+#define EXPERIMENTAL_Z_AXIS_MOVEMENT_API true 

--- a/Config.h
+++ b/Config.h
@@ -38,6 +38,7 @@
 #define motor_y_Acceleration 100000//4000 // 2400 1600 // 3200
 #define motor_z_Acceleration 100000//4000 // 2400 1600 // 3200
 
+// Defines the number of "dispenses" performed during priming
 #define PRIME_DISPENSE_NUM 2
 
 // Defines if the dispenser should home the Z-axis during homing

--- a/Config.h
+++ b/Config.h
@@ -40,3 +40,5 @@
 
 #define PRIME_DISPENSE_NUM 2
 #define EXPERIMENTAL_Z_AXIS_MOVEMENT_API true
+// Defines if the dispenser should home the Z-axis during homing
+#define EXPERIMENTAL_Z_HOMING true 

--- a/Config.h
+++ b/Config.h
@@ -6,17 +6,23 @@
 
 #define Limit_S_x_MIN 22 // 32
 #define Limit_S_y_MIN 32 // 33
+#define Limit_S_z_MIN 36
 
 //#define Limit_S_x_MAX 18
 //#define Limit_S_y_MAX 19
 #define Limit_S_x_MAX 46 //johari 20240610
 #define Limit_S_y_MAX 44 //johari 20240610
+#define Limit_S_z_MAX 38
+
 
 #define Motor_x_CW 27
 #define Motor_x_CLK 25
 
 #define Motor_y_CW 29
 #define Motor_y_CLK 31
+
+#define Motor_z_CW 35
+#define Motor_z_CLK 37
 
 //#define motor_x_speed 8000//, 2000
 //#define motor_y_speed 4800//, 1000
@@ -26,8 +32,10 @@
 
 #define motor_x_speed 8000 // 8000, 2000
 #define motor_y_speed 80000  // 4800, 1000
+#define motor_z_speed 80000  // 4800, 1000
 
 #define motor_x_Acceleration 100000//8000 // 4800, 3200
 #define motor_y_Acceleration 100000//4000 // 2400 1600 // 3200
+#define motor_z_Acceleration 100000//4000 // 2400 1600 // 3200
 
 #define PRIME_DISPENSE_NUM 2

--- a/Config.h
+++ b/Config.h
@@ -39,3 +39,4 @@
 #define motor_z_Acceleration 100000//4000 // 2400 1600 // 3200
 
 #define PRIME_DISPENSE_NUM 2
+#define EXPERIMENTAL_Z_AXIS_MOVEMENT_API true

--- a/PLC.cpp
+++ b/PLC.cpp
@@ -1,0 +1,90 @@
+/* Author : Ryan Y.
+ * Date created - 2024.08.27 - PLC Message Parsing Module
+ * Created for: Message type identification and data extraction
+ */
+
+#include "PLC.h"
+
+/**********************************************************************************************************
+* @brief parseReceivedMessage()
+* @details Parse received PLC message and identify message type with data extraction
+* @param receivedData - pointer to received message bytes
+* @param length - length of received message
+* @return PLCMessage struct containing message type and data
+**********************************************************************************************************/
+PLCMessage parseReceivedMessage(const byte *receivedData, int length) {
+  PLCMessage result;
+  result.type = MSG_UNKNOWN;
+  result.dataValue = 0;
+
+  // Copy raw data
+  for (int i = 0; i < 5 && i < length; i++) {
+    result.data[i] = receivedData[i];
+  }
+
+  // Check if message length is correct
+  if (length != messageLength) {
+    return result;
+  }
+
+  // Check if start and end bytes are correct
+  if (receivedData[0] != START_BYTE || receivedData[4] != END_BYTE) {
+    return result;
+  }
+
+  // Validate checksum (byte [3] should equal sum of byte [1] and [2])
+  if (receivedData[3] != ((receivedData[1] + receivedData[2]) & 0xFF)) {
+    return result; // Invalid checksum
+  }
+
+  // Extract data from byte [2]
+  result.dataValue = receivedData[2];
+
+  // Determine message type based on command byte [1]
+  switch (receivedData[1]) {
+  case 0x30:
+    result.type = MSG_START;
+    break;
+  case 0x31:
+    result.type = MSG_STOP;
+    break;
+  case 0x32:
+    result.type = MSG_PAUSE;
+    break;
+  case 0x42:
+    result.type = MSG_RAISE_Z;
+    break;
+  case 0x41:
+    result.type = MSG_LOWER_Z;
+    break;
+  default:
+    result.type = MSG_UNKNOWN;
+    break;
+  }
+
+  return result;
+}
+
+/**********************************************************************************************************
+* @brief getMessageTypeName()
+* @details Get string representation of message type for debugging
+* @param type - PLCMessageType enum value
+* @return const char* - string name of message type
+**********************************************************************************************************/
+const char *getMessageTypeName(PLCMessageType type) {
+  switch (type) {
+  case MSG_START:
+    return "START";
+  case MSG_STOP:
+    return "STOP";
+  case MSG_PAUSE:
+    return "PAUSE";
+  case MSG_RAISE_Z:
+    return "RAISE_Z";
+  case MSG_LOWER_Z:
+    return "LOWER_Z";
+  case MSG_UNKNOWN:
+  default:
+    return "UNKNOWN";
+  }
+}

--- a/PLC.h
+++ b/PLC.h
@@ -1,0 +1,48 @@
+/* Author : Ryan Y.
+ * Date created - 2024.08.27 - PLC Message Parsing Module
+ * Created for: Message type identification and data extraction
+ */
+
+#ifndef _PLC_H_
+#define _PLC_H_
+
+#include <stdint.h>
+
+#define START_BYTE 0xEF
+#define END_BYTE 0xFE
+
+// Define byte type if not already defined
+#ifndef byte
+typedef uint8_t byte;
+#endif
+
+enum PLCMessageType {
+  MSG_UNKNOWN = 0,
+  MSG_START = 1,
+  MSG_STOP = 2,
+  MSG_PAUSE = 3,
+  MSG_RAISE_Z = 4,
+  MSG_LOWER_Z = 5
+};
+
+// Structure to hold parsed message information
+struct PLCMessage {
+  PLCMessageType type;
+  byte data[5];  // Raw message data
+  byte dataValue; // Extracted data value (for messages with data)
+};
+
+// Shared message byte sequences
+static const byte expectedMessageStart[] = {START_BYTE, 0x30, 0x00, 0x30, END_BYTE};
+static const byte expectedMessageStop[] = {START_BYTE, 0x31, 0x00, 0x31, END_BYTE};
+static const byte expectedMessagePause[] = {START_BYTE, 0x32, 0x00, 0x32, END_BYTE};
+static const byte expectedMessageRaiseZ[] = {START_BYTE, 0x42, 0x00, 0x00, END_BYTE};
+static const byte expectedMessageLowerZ[] = {START_BYTE, 0x41, 0x00, 0x00, END_BYTE};
+static const byte responseMessage[] = {START_BYTE, 0x17, 0x00, 0x17, END_BYTE};
+static const int messageLength = 5;
+
+// Function declarations
+PLCMessage parseReceivedMessage(const byte* receivedData, int length);
+const char* getMessageTypeName(PLCMessageType type);
+
+#endif

--- a/Platform.h
+++ b/Platform.h
@@ -213,6 +213,8 @@ typedef PROGMEM const int32_t prog_int32_t;
 //20240917: erdiongson - Use the STEPS_PER_UNIT_Y 160L if we are using the new motor. use this moving forward
 //#define STEPS_PER_UNIT_Y 160L // (Y step motor specs: lead screw is 20mm, 1600 pulse/rev(8 microsteps driver), 20mm/3200 = 0.00625mm, 1mm/0.00625 = 160 steps/unit)
 
+#define STEPS_PER_UNIT_Z 30L
+
 extern Gpu_Hal_Context_t host, *phost;
 
 extern int tag;

--- a/SaveProfile.cpp
+++ b/SaveProfile.cpp
@@ -83,6 +83,7 @@ void PreLoadEEPROM(void)
       CurProf.passwordEnabled=TRUE;
       CurProf.vibrationDuration=2;
       CurProf.sizeFlag = 1;
+      CurProf.ZDip = 0.0;
       for(x=0;x<MAX_BUTTONS_X;x++)
         for(y=0;y<MAX_BUTTONS_Y;y++) CurProf.buttonStates[x][y]=TRUE;
     //try054 E }
@@ -108,6 +109,8 @@ void CheckProfile(void)
 	if(CurProf.Tube_No_x<0) CurProf.Tube_No_x=0;
 	if(CurProf.Tube_No_y>MAX_TUBES_Y) CurProf.Tube_No_y=MAX_TUBES_Y;
 	if(CurProf.Tube_No_y<0) CurProf.Tube_No_y=0;
+	if(CurProf.ZDip<0) CurProf.ZDip=0;
+	if(CurProf.ZDip>MAX_ZDIP) CurProf.ZDip=MAX_ZDIP;
 }
 uint8_t LoadProfile(void)
 {
@@ -124,6 +127,8 @@ uint8_t LoadProfile(void)
 	if(CurProf.trayOriginY>MAXORGY) CurProf.trayOriginY=MAXORGY;
 	if(CurProf.Tube_No_x>MAX_TUBES_X) CurProf.Tube_No_x=MAX_TUBES_X;
 	if(CurProf.Tube_No_y>MAX_TUBES_Y) CurProf.Tube_No_y=MAX_TUBES_Y;
+	if(CurProf.ZDip<0) CurProf.ZDip=0;
+	if(CurProf.ZDip>MAX_ZDIP) CurProf.ZDip=MAX_ZDIP;
 	return ret;
 }
 
@@ -213,6 +218,8 @@ void WriteProfileEEPROM(int address)//try054 , Profile &profile)
 	  address += sizeof(CurProf.dispenseEnabled);
     EEPROM.put(address, CurProf.sizeFlag);
     address += sizeof(CurProf.sizeFlag);
+    EEPROM.put(address, CurProf.ZDip);
+    address += sizeof(CurProf.ZDip);
 	//Dsprintln("size");
 	//Dprintln(sizeof(profile));
 
@@ -275,6 +282,8 @@ void ReadProfileEEPROM(int address)
     address += sizeof(CurProf.dispenseEnabled);
     EEPROM.get(address, CurProf.sizeFlag);
     address += sizeof(CurProf.sizeFlag);
+    EEPROM.get(address, CurProf.ZDip);
+    address += sizeof(CurProf.ZDip);
 
 	Dprint("add=",(float)address );
 
@@ -338,6 +347,8 @@ void ReadProfileMinEEPROM(int address)
     address += sizeof(SelectProf.dispenseEnabled);
     EEPROM.get(address, SelectProf.sizeFlag);
     address += sizeof(SelectProf.sizeFlag);
+    EEPROM.get(address, SelectProf.ZDip);
+    address += sizeof(SelectProf.ZDip);
 
 	Dprint("add=",(float)address );
 

--- a/SaveProfile.h
+++ b/SaveProfile.h
@@ -24,6 +24,9 @@ Date created - 2022.12.14 - XentiQ version
 #define MAXORGX 999//v204 99.9
 #define MAXORGY 999//v204 99.9
 
+#define MINZDIP 1
+#define MAXZDIP 999
+
 #define MINNUMX 1
 #define MINNUMY 1
 //Change MAXNUMX and MAXNUMY depending on the use;
@@ -61,6 +64,7 @@ typedef struct
     int16_t passwordEnabled = 0;
     int16_t vibrationDuration = 2;
     int16_t sizeFlag = 1; //small = 0; large = 1;
+    float ZDip = 0.0;
     // bool **buttonStates; // Declare as a double pointer
     bool buttonStates[MAX_BUTTONS_X][MAX_BUTTONS_Y]; // Declare as a static 2D array
 } Profile;
@@ -78,6 +82,7 @@ typedef struct
     float trayOriginY = 0.0;
     int16_t Cycles = 1;
     int16_t CurrentCycle = 0; // New field for storing the current cycle
+    float ZDip = 0.0;
     int16_t vibrationEnabled = 0;
     bool dispenseEnabled = false;
     int16_t passwordEnabled = 0;

--- a/XY_Table.cpp
+++ b/XY_Table.cpp
@@ -392,7 +392,7 @@ uint8_t vibrateAndCheckPause()
 bool primeDispenserHead() {
   bool cont;
   for (int i = 0; i < PRIME_DISPENSE_NUM; i++) {
-    cont = performVibrateAndDispenseOperations();
+    cont = performVibrateAndDispenseOperations(true);
     if (cont == false) {
       return false;
     }
@@ -629,7 +629,7 @@ void startProcess()
 }
 
 
-bool performVibrateAndDispenseOperations()
+bool performVibrateAndDispenseOperations(bool skipZDip) // default false
 {
 	bool_t ret=true; // return true if continue. return false if hardstop
 	uint8_t pausestop=0;
@@ -682,11 +682,11 @@ bool performVibrateAndDispenseOperations()
 	if(pausestop==PAUSE) if(!PauseOperation()) pausestop=STOP;
 	if(pausestop!=STOP)
 	{	
-    if (EXPERIMENTAL_Z_DIP && CurProf.ZDip > 0) headLowerZ(CurProf.ZDip);
+    if (EXPERIMENTAL_Z_DIP && !skipZDip && CurProf.ZDip > 0) headLowerZ(CurProf.ZDip);
 
 		pausestop=dispenseAndCheckPause();
 
-    if (EXPERIMENTAL_Z_DIP && CurProf.ZDip > 0) headRaiseZ(CurProf.ZDip);
+    if (EXPERIMENTAL_Z_DIP && !skipZDip && CurProf.ZDip > 0) headRaiseZ(CurProf.ZDip);
 
 		if(pausestop==STOP) Home_Menu(&host,  MAINMENU);
  		if(pausestop==PAUSE) if(!PauseOperation()) pausestop=STOP;

--- a/XY_Table.cpp
+++ b/XY_Table.cpp
@@ -682,11 +682,11 @@ bool performVibrateAndDispenseOperations()
 	if(pausestop==PAUSE) if(!PauseOperation()) pausestop=STOP;
 	if(pausestop!=STOP)
 	{	
-    if (CurProf.ZDip > 0) headLowerZ(CurProf.ZDip);
+    if (EXPERIMENTAL_Z_DIP && CurProf.ZDip > 0) headLowerZ(CurProf.ZDip);
 
 		pausestop=dispenseAndCheckPause();
 
-    if (CurProf.ZDip > 0) headRaiseZ(CurProf.ZDip);
+    if (EXPERIMENTAL_Z_DIP && CurProf.ZDip > 0) headRaiseZ(CurProf.ZDip);
 
 		if(pausestop==STOP) Home_Menu(&host,  MAINMENU);
  		if(pausestop==PAUSE) if(!PauseOperation()) pausestop=STOP;

--- a/XY_Table.cpp
+++ b/XY_Table.cpp
@@ -175,12 +175,13 @@ bool Homing()
 {
 	bool successx=FALSE;
 	bool successy=FALSE;
+	bool successz=FALSE;
 #if !DEBUG
   Serial.println("Homing Start...");
 #else
 	Dprint("Debugging Start...");
 #endif
- 
+
   stepper_x.moveTo(-320000);
 #if !DEBUG
   while (digitalRead(Limit_S_x_MAX) != 0)
@@ -208,7 +209,16 @@ bool Homing()
   stepper_y.setMaxSpeed(motor_y_speed);
   stepper_y.setAcceleration(motor_y_Acceleration);
 
-	return successx && successy;
+  #if EXPERIMENTAL_Z_HOMING
+    headRaiseZ(200); // Move Z-axis up by 200mm, or until the limit switch is hit
+    delay(20);
+    if (digitalRead(Limit_S_z_MIN) == 1 && digitalRead(Limit_S_z_MAX) == 0)
+      successz = TRUE;
+  #else
+    successz = TRUE;
+  #endif
+
+  return successx && successy && successz;
   //bool complete = true; //----johari---20092024---------------------------------------------------------------------------------------------------------------
 }
 
@@ -1032,6 +1042,14 @@ void setup()
         stepper_y.run();
         delay(1000);
     }
+
+    #if EXPERIMENTAL_Z_HOMING
+      if(digitalRead(Limit_S_z_MAX) == 0)
+      {
+        Dprint("motor z out","\n");
+        headLowerZ(100);
+      }
+    #endif
      
 #endif
 

--- a/XY_Table.cpp
+++ b/XY_Table.cpp
@@ -155,7 +155,7 @@ void headLowerZ(int distance_mm) {
   #if !DEBUG
     stepper_z.setCurrentPosition(0);
     stepper_z.moveTo(-STEPS_PER_UNIT_Z * distance_mm);
-    while (stepper_z.isRunning() && digitalRead(Limit_S_z_MIN) == HIGH) {
+    while (stepper_z.isRunning() && digitalRead(Limit_S_z_MAX) == HIGH) {
       stepper_z.run();
     }
   #endif
@@ -165,7 +165,7 @@ void headRaiseZ(int distance_mm) {
   #if !DEBUG
     stepper_z.setCurrentPosition(0);
     stepper_z.moveTo(STEPS_PER_UNIT_Z * distance_mm);
-    while (stepper_z.isRunning() && digitalRead(Limit_S_z_MAX) == HIGH) {
+    while (stepper_z.isRunning() && digitalRead(Limit_S_z_MIN) == HIGH) {
       stepper_z.run();
     }
   #endif
@@ -212,7 +212,7 @@ bool Homing()
   #if EXPERIMENTAL_Z_HOMING
     headRaiseZ(200); // Move Z-axis up by 200mm, or until the limit switch is hit
     delay(20);
-    if (digitalRead(Limit_S_z_MIN) == 1 && digitalRead(Limit_S_z_MAX) == 0)
+    if (digitalRead(Limit_S_z_MAX) == 1 && digitalRead(Limit_S_z_MIN) == 0)
       successz = TRUE;
   #else
     successz = TRUE;
@@ -1044,7 +1044,7 @@ void setup()
     }
 
     #if EXPERIMENTAL_Z_HOMING
-      if(digitalRead(Limit_S_z_MAX) == 0)
+      if(digitalRead(Limit_S_z_MIN) == 0)
       {
         Dprint("motor z out","\n");
         headLowerZ(100);

--- a/XY_Table.cpp
+++ b/XY_Table.cpp
@@ -1211,7 +1211,16 @@ void loop()
       //    Serial.print("DATA KIRIM KIRIM KIRIM"); 
       //    Serial.print(complete);
       //   }
-     }   
-   }
+     }
+    else if (parsedMsg.type == MSG_LOWER_Z)
+    {
+      headLowerZ(parsedMsg.dataValue);
+    }
+    else if (parsedMsg.type == MSG_RAISE_Z)
+    {
+      headRaiseZ(parsedMsg.dataValue);
+    }
+   } 
+   
 //--------------------------------------johari-23092024---------------------------------------------------------------------------------------------------------------------------------
 }

--- a/XY_Table.cpp
+++ b/XY_Table.cpp
@@ -1014,10 +1014,10 @@ void setup()
 	
 #if !DEBUG
 
-    if( digitalRead(Limit_S_x_MIN) == 0)
+    if( digitalRead(Limit_S_x_MAX) == 0)
     {
       Dprint("motor x out","\n");
-      stepper_x.moveTo(-2000);
+      stepper_x.moveTo(2000);
       //while (digitalRead(Limit_S_x_MIN) == 0)
       while (stepper_x.distanceToGo() != 0)
         stepper_x.run();

--- a/XY_Table.cpp
+++ b/XY_Table.cpp
@@ -668,7 +668,12 @@ bool performVibrateAndDispenseOperations()
 	if(pausestop==PAUSE) if(!PauseOperation()) pausestop=STOP;
 	if(pausestop!=STOP)
 	{	
+    if (CurProf.ZDip > 0) headLowerZ(CurProf.ZDip);
+
 		pausestop=dispenseAndCheckPause();
+
+    if (CurProf.ZDip > 0) headRaiseZ(CurProf.ZDip);
+
 		if(pausestop==STOP) Home_Menu(&host,  MAINMENU);
  		if(pausestop==PAUSE) if(!PauseOperation()) pausestop=STOP;
 	}

--- a/XY_Table.cpp
+++ b/XY_Table.cpp
@@ -17,6 +17,7 @@
 #include "SaveProfile.h"
 #include "XY_Table.h"
 #include "UART.h"
+#include "PLC.h"
 
 Gpu_Hal_Context_t host, *phost;
 Profile CurProf; //current profile
@@ -63,12 +64,7 @@ volatile char OpMode = MANUAL_MODE;
 //-----------------------------------------------johari-23092024 PLC-----------------------------------------------------------------------------------------------------------------------//
 #define PLC_SERIAL Serial3
 
-// Define the input and output byte sequences
- const byte expectedMessageStart[] = {0xEF, 0x30, 0x00, 0x30, 0xFE};
- const byte expectedMessageStop[] = {0xEF, 0x31, 0x00, 0x31, 0xFE};
- const byte expectedMessagePause[] = {0xEF, 0x32, 0x00, 0x32, 0xFE};
- const byte responseMessage[] = {0xEF, 0x17, 0x00, 0x17, 0xFE};
- const int messageLength = 5;
+// Message definitions now in PLCMessages.h/cpp
 //---------------------------------------------------------------------------------------------------------------------johari-23092024 PLC------------------------------------------------// 
 
 //20240906: erdiongson - for UART 3 ISR Protocol
@@ -1117,8 +1113,8 @@ void loop()
             startProcess();
             Dprint("Cycle end","\n");
             Homing();
-            //CurX=0;
-            //CurY=0;
+            CurX=0;
+            CurY=0;
             Home_Menu(&host, MAINMENU);
             keypressed=0;
             break;
@@ -1176,22 +1172,23 @@ void loop()
    {
     Serial.println("------------PLC Serial Message Available - START------------");    
     byte receivedMessage[messageLength];
-    bool validMessage = true;
     bool complete = false; 
-       //uint8_t ret= 0; //johari---------17092024-------------------------------------
+    //uint8_t ret= 0; //johari---------17092024-------------------------------------
+    
     // Read the incoming bytes
     for (int i = 0; i < messageLength; i++)
      {
       receivedMessage[i] = PLC_SERIAL.read();
-      if (receivedMessage[i] != expectedMessageStart[i])
-      {
-        validMessage = false; // If any byte doesn't match, it's not the expected message
-      }
      }
+    
+    // Parse the received message using new PLC logic
+    PLCMessage parsedMsg = parseReceivedMessage(receivedMessage, messageLength);
+    
+    Serial.print("Received message type: ");
+    Serial.println(getMessageTypeName(parsedMsg.type));
  
-    if (validMessage)
+    if (parsedMsg.type == MSG_START)
      {
-      
       CurX=0;
       CurY=0;
       TotalTubeLeft=(CurProf.Tube_No_x)*(CurProf.Tube_No_y);
@@ -1206,13 +1203,14 @@ void loop()
       keypressed=0;
       Serial.println("------------------------------------------------------------");
       Serial.print("DATA START START START"); 
-//      if (complete=true)
-//       {
-//        PLC_SERIAL.write(responseMessage, messageLength);//-------23092024--PLC----------------------------------------------johari-------------------------------------------------
-//        //complete = false; 
-//        Serial.print("DATA KIRIM KIRIM KIRIM"); 
-//        Serial.print(complete);
-//       }
+
+      //  if (complete=true)
+      //   {
+      //    PLC_SERIAL.write(responseMessage, messageLength);//-------23092024--PLC----------------------------------------------johari-------------------------------------------------
+      //    //complete = false; 
+      //    Serial.print("DATA KIRIM KIRIM KIRIM"); 
+      //    Serial.print(complete);
+      //   }
      }   
    }
 //--------------------------------------johari-23092024---------------------------------------------------------------------------------------------------------------------------------

--- a/XY_Table.cpp
+++ b/XY_Table.cpp
@@ -152,19 +152,23 @@ void init_Motors()
 }
 
 void headLowerZ(int distance_mm) {
-  stepper_z.setCurrentPosition(0);
-  stepper_z.moveTo(-STEPS_PER_UNIT_Z * distance_mm);
-  while (stepper_z.isRunning() && digitalRead(Limit_S_z_MIN) == HIGH) {
-    stepper_z.run();
-  }
+  #if !DEBUG
+    stepper_z.setCurrentPosition(0);
+    stepper_z.moveTo(-STEPS_PER_UNIT_Z * distance_mm);
+    while (stepper_z.isRunning() && digitalRead(Limit_S_z_MIN) == HIGH) {
+      stepper_z.run();
+    }
+  #endif
 }
 
 void headRaiseZ(int distance_mm) {
-  stepper_z.setCurrentPosition(0);
-  stepper_z.moveTo(STEPS_PER_UNIT_Z * distance_mm);
-  while (stepper_z.isRunning() && digitalRead(Limit_S_z_MAX) == HIGH) {
-    stepper_z.run();
-  }
+  #if !DEBUG
+    stepper_z.setCurrentPosition(0);
+    stepper_z.moveTo(STEPS_PER_UNIT_Z * distance_mm);
+    while (stepper_z.isRunning() && digitalRead(Limit_S_z_MAX) == HIGH) {
+      stepper_z.run();
+    }
+  #endif
 }
 
 bool Homing()

--- a/XY_Table.cpp
+++ b/XY_Table.cpp
@@ -29,6 +29,7 @@ uint8_t CurProfNum;//current profile id
 
 AccelStepper stepper_x(1, Motor_x_CLK, Motor_x_CW);
 AccelStepper stepper_y(1, Motor_y_CLK, Motor_y_CW);
+AccelStepper stepper_z(1, Motor_z_CLK, Motor_z_CW);
 
 //Profile profile; // Create a profile object
 ActionState action;
@@ -133,8 +134,10 @@ void GPIO_Setup()
   pinMode(Vibrate, OUTPUT);
   pinMode(Limit_S_x_MIN, INPUT_PULLUP);
   pinMode(Limit_S_y_MIN, INPUT_PULLUP);
+  pinMode(Limit_S_z_MIN, INPUT_PULLUP);
   pinMode(Limit_S_x_MAX, INPUT_PULLUP);
   pinMode(Limit_S_y_MAX, INPUT_PULLUP);
+  pinMode(Limit_S_z_MAX, INPUT_PULLUP);
 }
 
 void init_Motors()
@@ -143,11 +146,29 @@ void init_Motors()
   stepper_x.setMaxSpeed(motor_x_speed);
   stepper_x.setAcceleration(motor_x_Acceleration);
 
-   stepper_y.setSpeed(motor_y_speed);
+  stepper_y.setSpeed(motor_y_speed);
   stepper_y.setMaxSpeed(motor_y_speed);
   stepper_y.setAcceleration(motor_y_Acceleration);
-  //stepper_x.setSpeed(10000);
-  //stepper_y.setSpeed(10000);
+
+  stepper_z.setSpeed(motor_z_speed);
+  stepper_z.setMaxSpeed(motor_z_speed);
+  stepper_z.setAcceleration(motor_z_Acceleration);
+}
+
+void headLowerZ(int distance_mm) {
+  stepper_z.setCurrentPosition(0);
+  stepper_z.moveTo(-STEPS_PER_UNIT_Z * distance_mm);
+  while (stepper_z.isRunning() && digitalRead(Limit_S_z_MIN) == HIGH) {
+    stepper_z.run();
+  }
+}
+
+void headRaiseZ(int distance_mm) {
+  stepper_z.setCurrentPosition(0);
+  stepper_z.moveTo(STEPS_PER_UNIT_Z * distance_mm);
+  while (stepper_z.isRunning() && digitalRead(Limit_S_z_MAX) == HIGH) {
+    stepper_z.run();
+  }
 }
 
 bool Homing()

--- a/XY_Table.cpp
+++ b/XY_Table.cpp
@@ -1223,11 +1223,15 @@ void loop()
      }
     else if (parsedMsg.type == MSG_LOWER_Z)
     {
-      headLowerZ(parsedMsg.dataValue);
+      #if EXPERIMENTAL_Z_AXIS_MOVEMENT_API
+        headLowerZ(parsedMsg.dataValue);
+      #endif
     }
     else if (parsedMsg.type == MSG_RAISE_Z)
     {
-      headRaiseZ(parsedMsg.dataValue);
+      #if EXPERIMENTAL_Z_AXIS_MOVEMENT_API
+        headRaiseZ(parsedMsg.dataValue);
+      #endif
     }
    } 
    

--- a/XY_Table.h
+++ b/XY_Table.h
@@ -66,7 +66,7 @@ void Run_profile();
 void xy_init(void);
 void xy_main(void);
 
-bool performVibrateAndDispenseOperations();
+bool performVibrateAndDispenseOperations(bool skipZDip = false);
 bool primeDispenserHead();
 void startProcess();
 void resumeProcess();

--- a/XY_Table.h
+++ b/XY_Table.h
@@ -70,5 +70,7 @@ bool primeDispenserHead();
 void startProcess();
 void resumeProcess();
 
+void headLowerZ(int distance_mm);
+void headRaiseZ(int distance_mm);
 
 #endif /*_XY_TABLE_H_*/

--- a/XY_Table.h
+++ b/XY_Table.h
@@ -14,6 +14,7 @@ Date created - 2022.12.14 - XentiQ version
 //for (S) 200x300 - MAX_TUBES_X 20; MAX_TUBES_Y 27
 #define MAX_TUBES_X 42//try054 33
 #define MAX_TUBES_Y 33
+#define MAX_ZDIP 2000 // 20cm
 
 #define MANUAL_MODE 1
 #define AUTO_MODE 2


### PR DESCRIPTION
## Summary of Changes

### Priming Support
- Added priming step before dispensing cycle.  
- Dispenser moves to **bottom-left** position, dispenses `PRIME_DISPENSE_NUM` times (default = 2) without Z-Dip.  
- Uses vibration/duration settings from loaded profile.  
- After priming, cycle continues from first tube position.  

### Z-Axis Movement & Homing
- Integrated Z-axis motor + limit switches with configurable constants.  
- Z-axis homes to **MIN limit switch** (top position).  
- Optional toggle with `EXPERIMENTAL_Z_HOMING` flag.  

### Z-Dip Support
- During dispensing, head lowers by profile-configured distance, then retracts.  
- Toggleable via `EXPERIMENTAL_Z_DIP` flag.  

### Z-Axis Movement API via PLC
- New PLC API for raising/lowering head by a specified distance (mm).  
- Enabled with `EXPERIMENTAL_Z_AXIS_MOVEMENT_API` flag, usable from main menu.  
